### PR TITLE
Support more metrics

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -162,6 +162,18 @@ func (mb *SquareMetrics) SerializeMetrics() []map[string]interface{} {
 			nvs = append(nvs, tuple{name, metric.Value()})
 		case metrics.GaugeFloat64:
 			nvs = append(nvs, tuple{name, metric.Value()})
+		case metrics.Histogram:
+			histogram := metric.Snapshot()
+			nvs = append(nvs, []tuple{
+				{fmt.Sprintf("%s.count", name), histogram.Count()},
+				{fmt.Sprintf("%s.min", name), histogram.Min()},
+				{fmt.Sprintf("%s.max", name), histogram.Max()},
+				{fmt.Sprintf("%s.mean", name), histogram.Mean()},
+				{fmt.Sprintf("%s.50-percentile", name), histogram.Percentile(0.5)},
+				{fmt.Sprintf("%s.75-percentile", name), histogram.Percentile(0.75)},
+				{fmt.Sprintf("%s.95-percentile", name), histogram.Percentile(0.95)},
+				{fmt.Sprintf("%s.99-percentile", name), histogram.Percentile(0.99)},
+			}...)
 		case metrics.Timer:
 			timer := metric.Snapshot()
 			nvs = append(nvs, []tuple{

--- a/metrics.go
+++ b/metrics.go
@@ -169,16 +169,10 @@ func (mb *SquareMetrics) SerializeMetrics() []map[string]interface{} {
 				{fmt.Sprintf("%s.min", name), timer.Min()},
 				{fmt.Sprintf("%s.max", name), timer.Max()},
 				{fmt.Sprintf("%s.mean", name), timer.Mean()},
-				{fmt.Sprintf("%s.std-dev", name), timer.StdDev()},
-				{fmt.Sprintf("%s.one-minute", name), timer.Rate1()},
-				{fmt.Sprintf("%s.five-minute", name), timer.Rate5()},
-				{fmt.Sprintf("%s.fifteen-minute", name), timer.Rate15()},
-				{fmt.Sprintf("%s.mean-rate", name), timer.RateMean()},
 				{fmt.Sprintf("%s.50-percentile", name), timer.Percentile(0.5)},
 				{fmt.Sprintf("%s.75-percentile", name), timer.Percentile(0.75)},
 				{fmt.Sprintf("%s.95-percentile", name), timer.Percentile(0.95)},
 				{fmt.Sprintf("%s.99-percentile", name), timer.Percentile(0.99)},
-				{fmt.Sprintf("%s.999-percentile", name), timer.Percentile(0.999)},
 			}...)
 		}
 	})

--- a/metrics.go
+++ b/metrics.go
@@ -109,7 +109,6 @@ func (mb *SquareMetrics) collectSystemMetrics() {
 
 		update("runtime.mem.stack.inuse", mem.StackInuse)
 		update("runtime.mem.stack.sys", mem.StackSys)
-		update("runtime.mem.stack.sys", mem.StackSys)
 
 		update("runtime.goroutines", uint64(runtime.NumGoroutine()))
 		update("runtime.cgo-calls", uint64(runtime.NumCgoCall()))


### PR DESCRIPTION
r: @alokmenghrajani @mcpherrinm 
Changes:
- reports histogram of GC pause durations, other extra metrics
- drops some fields we're not using from serialization code
